### PR TITLE
[BUGFIX] Fix accessing non existend offset

### DIFF
--- a/Sniffs/Commenting/ValidCommentLineLengthSniff.php
+++ b/Sniffs/Commenting/ValidCommentLineLengthSniff.php
@@ -100,7 +100,7 @@ class TYPO3SniffPool_Sniffs_Commenting_ValidCommentLineLengthSniff implements PH
         $lastToken = $stackPtr;
 
         $stackPtr++;
-        while ($tokens[$stackPtr]['line'] === $line) {
+        while (isset($tokens[$stackPtr]) && $tokens[$stackPtr]['line'] === $line) {
             $lastToken = $stackPtr;
             $stackPtr++;
         }


### PR DESCRIPTION
- As the pointer is raised and not checked for validity it can raise a
  PHP Notice
